### PR TITLE
Django 1.7

### DIFF
--- a/authority/utils.py
+++ b/authority/utils.py
@@ -3,7 +3,7 @@ from django.contrib import auth
 
 
 def get_user_class():
-    if hasattr(settings, "AUTH_USER_MODE"):
+    if hasattr(settings, "AUTH_USER_MODEL"):
         return settings.AUTH_USER_MODEL
     elif hasattr(auth, "get_user_model"):
         return auth.get_user_model()

--- a/authority/utils.py
+++ b/authority/utils.py
@@ -1,8 +1,11 @@
+from django.conf import settings
 from django.contrib import auth
 
 
 def get_user_class():
-    if hasattr(auth, "get_user_model"):
+    if hasattr(settings, "AUTH_USER_MODE"):
+        return settings.AUTH_USER_MODEL
+    elif hasattr(auth, "get_user_model"):
         return auth.get_user_model()
     else:
         return auth.models.User


### PR DESCRIPTION
In django 1.7, app-loading was refactor and because `django-authority` uses `get_user_model`, an `AppRegistryNotReady: Models aren't loaded yet.` was thrown. 

A common fix to this error is to use `settings.AUTH_USER_MODEL`, specified in [docs](http://django.readthedocs.org/en/latest/ref/applications.html#applications-troubleshooting)
