### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ The main website for django-authority is
 `in-development version`_ of django-authority with
 ``pip install django-authority==dev`` or ``easy_install django-authority==dev``.
 
-.. _`django-authority.readthedocs.org`: http://django-authority.readthedocs.org/
+.. _`django-authority.readthedocs.org`: https://django-authority.readthedocs.io/
 .. _in-development version: https://github.com/jazzband/django-authority/archive/master.zip#egg=django-authority-dev
 
 Example


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.