### PR TITLE
Add support for Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - TOXENV=py33-dj18
   - TOXENV=py34-dj18
   - TOXENV=py35-dj18
+  - TOXENV=py27-dj111
 install:
 - pip install tox codecov
 script: tox -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,11 @@ cache:
 env:
   matrix:
   - TOXENV=py27-dj18
-  - TOXENV=py33-dj18
   - TOXENV=py34-dj18
   - TOXENV=py35-dj18
   - TOXENV=py27-dj111
+  - TOXENV=py34-dj111
+  - TOXENV=py35-dj111
 install:
 - pip install tox codecov
 script: tox -v

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,11 @@ html version using the setup.py::
 Changelog:
 ==========
 
+0.12 (TBD):
+-----------------
+
+* Added support for Django 1.11
+
 0.11 (2016-07-17):
 -----------------
 

--- a/authority/views.py
+++ b/authority/views.py
@@ -25,8 +25,9 @@ def add_permission(request, app_label, module_name, pk, approved=False,
                    template_name='authority/permission_form.html',
                    extra_context=None, form_class=UserPermissionForm):
     codename = request.POST.get('codename', None)
-    model = apps.get_model(app_label, module_name)
-    if model is None:
+    try:
+        model = apps.get_model(app_label, module_name)
+    except LookupError:
         return permission_denied(request)
     obj = get_object_or_404(model, pk=pk)
     next = get_next(request, obj)
@@ -108,5 +109,8 @@ def permission_denied(request, template_name=None, extra_context=None):
     }
     if extra_context:
         context.update(extra_context)
-    return HttpResponseForbidden(loader.render_to_string(template_name,
-                                                         context, request))
+    return HttpResponseForbidden(loader.render_to_string(
+        template_name=template_name,
+        context=context,
+        request=request,
+    ))

--- a/example/exampleapp/permissions.py
+++ b/example/exampleapp/permissions.py
@@ -7,7 +7,7 @@ from authority.permissions import BasePermission
 class FlatPagePermission(BasePermission):
     """
     This class contains a bunch of checks:
-    
+
     1. the default checks 'add_flatpage', 'browse_flatpage',
        'change_flatpage' and 'delete_flatpage'
     2. the custom checks:
@@ -49,4 +49,4 @@ class FlatPagePermission(BasePermission):
         return False
     top_secret.short_description=_('Is allowed to see top secret flatpages')
 
-authority.register(FlatPage, FlatPagePermission)
+authority.sites.register(FlatPage, FlatPagePermission)

--- a/example/exampleapp/tests.py
+++ b/example/exampleapp/tests.py
@@ -1,23 +1,26 @@
-"""
-This file demonstrates two different styles of tests (one doctest and one
-unittest). These will both pass when you run "manage.py test".
-
-Replace these with more appropriate tests for your application.
-"""
-
+from django.core.urlresolvers import reverse
 from django.test import TestCase
 
-class SimpleTest(TestCase):
-    def test_basic_addition(self):
-        """
-        Tests that 1 + 1 always equals 2.
-        """
-        self.failUnlessEqual(1 + 1, 2)
+from authority.compat import get_user_model
 
-__test__ = {"doctest": """
-Another way to test that 1 + 1 is equal to 2.
 
->>> 1 + 1 == 2
-True
-"""}
+class AddPermissionTestCase(TestCase):
+    def test_add_permission_permission_denied_is_403(self):
+        user = get_user_model().objects.create(
+            username='foo',
+            email='foo@example.com',
+        )
+        user.set_password('pw')
+        user.save()
 
+        assert self.client.login(username='foo@example.com', password='pw')
+        url = reverse(
+            'authority-add-permission-request',
+            kwargs={
+                'app_label': 'foo',
+                'module_name': 'Bar',
+                'pk': 1,
+            },
+        )
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 403)

--- a/example/settings.py
+++ b/example/settings.py
@@ -54,11 +54,6 @@ INTERNAL_IPS = ('127.0.0.1',)
 
 
 TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.core.context_processors.auth',
-    'django.core.context_processors.debug',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.media',
-    'django.core.context_processors.request',
 )
 
 ROOT_URLCONF = 'example.urls'
@@ -80,14 +75,28 @@ if VERSION >= (1, 5):
     INSTALLED_APPS = INSTALLED_APPS + ('example.users',)
     AUTH_USER_MODEL = 'users.User'
 
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.load_template_source',
-    'django.template.loaders.app_directories.load_template_source',
-)
-
-TEMPLATE_DIRS = (
-    os.path.join(PROJECT_ROOT, "templates"),
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            # insert your TEMPLATE_DIRS here
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
+                # list if you haven't customized them:
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
 
 # Use local_settings.py for things to override privately
 try:

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,39 +1,42 @@
-try:
-    from django.conf.urls import patterns, include, handler500, url
-except ImportError:  # django < 1.4
-    from django.conf.urls.defaults import patterns, include, handler500, url
+import django.contrib.auth.views
+from django.conf.urls import include, handler500, url
 from django.conf import settings
-from django.contrib import admin
-import authority
 
-admin.autodiscover()
-authority.autodiscover()
-
-handler500 # Pyflakes
+import authority.views
+import authority.urls
+import example.exampleapp.views
 
 from exampleapp.forms import SpecialUserPermissionForm
 
-urlpatterns = patterns('',
-    (r'^admin/(.*)', admin.site.root),
-    #('^admin/', include(admin.site.urls)),
-    url(r'^authority/permission/add/(?P<app_label>[\w\-]+)/(?P<module_name>[\w\-]+)/(?P<pk>\d+)/$',
-        view='authority.views.add_permission',
+authority.autodiscover()
+
+handler500  # flake8
+
+urlpatterns = (
+    url(
+        r'^authority/permission/add/(?P<app_label>[\w\-]+)/(?P<module_name>[\w\-]+)/(?P<pk>\d+)/$',  # noqa
+        view=authority.views.add_permission,
         name="authority-add-permission",
         kwargs={'approved': True, 'form_class': SpecialUserPermissionForm}
     ),
-    url(r'^request/add/(?P<app_label>[\w\-]+)/(?P<module_name>[\w\-]+)/(?P<pk>\d+)/$',
-        view='authority.views.add_permission',
+    url(
+        r'^request/add/(?P<app_label>[\w\-]+)/(?P<module_name>[\w\-]+)/(?P<pk>\d+)/$',  # noqa
+        view=authority.views.add_permission,
         name="authority-add-permission-request",
         kwargs={'approved': False, 'form_class': SpecialUserPermissionForm}
     ),
-    (r'^authority/', include('authority.urls')),
-    (r'^accounts/login/$', 'django.contrib.auth.views.login'),
-    url(r'^(?P<url>[\/0-9A-Za-z]+)$', 'example.exampleapp.views.top_secret', {'lala': 'oh yeah!'}),
+    url(r'^authority/', include(authority.urls)),
+    url(r'^accounts/login/$', django.contrib.auth.views.login),
+    url(
+        r'^(?P<url>[\/0-9A-Za-z]+)$',
+        example.exampleapp.views.top_secret,
+        {'lala': 'oh yeah!'},
+    ),
 )
 
 if settings.DEBUG:
-    urlpatterns += patterns('',
-        (r'^media/(?P<path>.*)$', 'django.views.static.serve', {
+    urlpatterns += (
+        url(r'^media/(?P<path>.*)$', django.views.static.serve, {
             'document_root': settings.MEDIA_ROOT,
         }),
     )

--- a/example/users/models.py
+++ b/example/users/models.py
@@ -7,6 +7,7 @@ class User(AbstractBaseUser, PermissionsMixin):
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = ['first_name', 'last_name']
 
+    username = models.CharField(max_length=100)
     first_name = models.CharField(max_length=50)
     last_name = models.CharField(max_length=50)
     email = models.EmailField(unique=True)

--- a/example/users/models.py
+++ b/example/users/models.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin
+from django.contrib.auth.models import UserManager
 from django.db import models
 from django.utils import timezone
 
@@ -15,3 +16,5 @@ class User(AbstractBaseUser, PermissionsMixin):
     is_staff = models.BooleanField(default=False)
     is_active = models.BooleanField(default=True)
     date_joined = models.DateTimeField(default=timezone.now)
+
+    objects = UserManager()

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 usedevelop = True
 minversion = 1.8
 envlist =
-    py{27,33,34,35}-dj{18,19,110}
+    py{27,33,34,35}-dj{18,19,110,111}
 
 [testenv]
 basepython =
@@ -17,3 +17,4 @@ deps =
     dj18: Django<1.9
     dj19: Django<1.10
     dj110: Django<1.11
+    dj111: Django<1.12

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ basepython =
     py34: python3.4
     py35: python3.5
 usedevelop = true
-commands = python example/manage.py test authority
+commands = python example/manage.py test authority exampleapp
 deps =
     dj18: Django<1.9
     dj19: Django<1.10


### PR DESCRIPTION
It looks like upstream already supports Django 1.11, but some updates needed to be made for tests. 

This also fixes a bug with Django 1.8 and `permission_required`. Basically [render_to_string](https://docs.djangoproject.com/en/1.8/topics/templates/#django.template.loader.render_to_string) has an order for parameters that we aren't respecting. In your code, it's not actually possible to get into that code path, but we are calling it directly in our code. So I fixed your code to allow getting into that code path again, then fixed the issue (with a test to make sure it doesn't break in the future).