### PR TITLE
Fixes ActionErrorList creation resulting in AttributeError

### DIFF
--- a/authority/admin.py
+++ b/authority/admin.py
@@ -40,6 +40,7 @@ class ActionPermissionInline(PermissionInline):
 
 class ActionErrorList(forms.utils.ErrorList):
     def __init__(self, inline_formsets):
+        super(ActionErrorList, self).__init__()
         for inline_formset in inline_formsets:
             self.extend(inline_formset.non_form_errors())
             for errors_in_inline_form in inline_formset.errors:


### PR DESCRIPTION
ActionErrorList is derived from django.forms.utils.ErrorList. Currently ActionErrorList does not call the `__init__` method of its base class. The base class requires its `__init__` method to be called before `extend` is called otherwise it results in an AttributeError `'ActionErrorList' object has no attribute 'data'`.

I found this while moving a project over to Django 1.11.28 under Python 2.7 and 3.7 