### PR TITLE
Fixes cycle syntax

### DIFF
--- a/authority/templates/admin/edit_inline/action_tabular.html
+++ b/authority/templates/admin/edit_inline/action_tabular.html
@@ -19,7 +19,7 @@
         {% if inline_admin_form.form.non_field_errors %}
         <tr><td colspan="{{ inline_admin_form.field_count }}">{{ inline_admin_form.form.non_field_errors }}</td></tr>
         {% endif %}
-        <tr class="{% cycle row1,row2 %} {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}">
+        <tr class="{% cycle 'row1' 'row2' %} {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}">
 
         <td class="original">
           {% if inline_admin_form.original or inline_admin_form.show_url %}<p>


### PR DESCRIPTION
Corrects `cycle` syntax. What was being used was an old form of the syntax that was [deprecated in Django 1.9 and removed in 1.10 ](https://docs.djangoproject.com/en/dev/releases/1.9/#cycle-syntax-with-comma-separated-arguments)
I believe this change to be correct as this makes the syntax follow that of [Django 1.8 - templates - builtins - cycle](https://docs.djangoproject.com/en/1.8/ref/templates/builtins/#cycle). Which I believe is the minimum version of [Django support required by django-authority since version 0.11](https://github.com/jazzband/django-authority#011-2016-07-17)

The current code when rendered results in a `TemplateSyntaxError: No named cycles in template. 'row1,row2' is not defined`. This change causes is not to happen.

I found this while moving a project over to Django 1.11.28 under Python 2.7 and 3.7